### PR TITLE
Added CGBase.h to avoid missing CGFloat type issues.

### DIFF
--- a/src/NSUserDefaults+Convenience.h
+++ b/src/NSUserDefaults+Convenience.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreGraphics/CGBase.h>
 
 // Macros
 #define NSStandardUserDefaults [NSUserDefaults standardUserDefaults]


### PR DESCRIPTION
Just added one line to import <CoreGraphics/CGBase.h> and, thus, avoiding the missing type 'CGFloat' when importing this library without having imported UIKit first (for example, when importing from a Prefix Header).