### PR TITLE
Fixes for iCloud Handler.

### DIFF
--- a/NSUserDefaults-Convenience.podspec
+++ b/NSUserDefaults-Convenience.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
 
 
   s.name         = "NSUserDefaults-Convenience"
-  s.version      = "0.0.1"
+  s.version      = "0.0.2"
   s.summary      = "NSUserDefaults-Convenience is a category on NSUserDefaults"
 
   s.description  = <<-DESC


### PR DESCRIPTION
Added some code to manage the obscured notification object from `NSNotificationCenter` which wasn't being handled. Avoids Xcode warning.